### PR TITLE
Blast mock

### DIFF
--- a/script/deploy_testnet.s.sol
+++ b/script/deploy_testnet.s.sol
@@ -7,7 +7,7 @@ import "../src/FantasyCards.sol";
 import "../src/Exchange.sol";
 import "../src/ExecutionDelegate.sol";
 import "../src/Minter.sol";
-import "../test/tokens/WrappedETH_ownable.sol";
+import "../test/tokens/WrappedETH_Ownable.sol";
 
 contract Deploy is Script {
     FantasyCards fantasyCards;

--- a/src/Exchange.sol
+++ b/src/Exchange.sol
@@ -49,12 +49,8 @@ contract Exchange is IExchange, EIP712, Ownable, ReentrancyGuard {
         uint256 _protocolFeeBps,
         address _executionDelegate
     ) EIP712("Exchange", "1") Ownable(msg.sender) {
-        // REVIEW: When this contract is live
-        // IBlast(0x4300000000000000000000000000000000000002)
-        //     .configureClaimableGas();
-        // IBlast(0x4300000000000000000000000000000000000002).configureGovernor(
-        //     msg.sender
-        // );
+        IBlast(0x4300000000000000000000000000000000000002).configureClaimableGas();
+        IBlast(0x4300000000000000000000000000000000000002).configureGovernor(msg.sender);
         _setProtocolFeeRecipient(_protocolFeeRecipient);
         _setProtocolFeeBps(_protocolFeeBps);
         _setExecutionDelegate(_executionDelegate);

--- a/src/ExecutionDelegate.sol
+++ b/src/ExecutionDelegate.sol
@@ -39,12 +39,8 @@ contract ExecutionDelegate is IExecutionDelegate, AccessControlDefaultAdminRules
     }
 
     constructor() AccessControlDefaultAdminRules(0, msg.sender) {
-        // REVIEW: When this contract is live
-        // IBlast(0x4300000000000000000000000000000000000002)
-        //     .configureClaimableGas();
-        // IBlast(0x4300000000000000000000000000000000000002).configureGovernor(
-        //     msg.sender
-        // );
+        IBlast(0x4300000000000000000000000000000000000002).configureClaimableGas();
+        IBlast(0x4300000000000000000000000000000000000002).configureGovernor(msg.sender);
     }
 
     /**

--- a/src/FantasyCards.sol
+++ b/src/FantasyCards.sol
@@ -47,12 +47,8 @@ contract FantasyCards is Context, IFantasyCards, AccessControlDefaultAdminRules 
      * @dev Initializes the contract by setting a `name` and a `symbol` to the token collection.
      */
     constructor() AccessControlDefaultAdminRules(0, msg.sender) {
-        // REVIEW: When this contract is live
-        // IBlast(0x4300000000000000000000000000000000000002)
-        //     .configureClaimableGas();
-        // IBlast(0x4300000000000000000000000000000000000002).configureGovernor(
-        //     msg.sender
-        // );
+        IBlast(0x4300000000000000000000000000000000000002).configureClaimableGas();
+        IBlast(0x4300000000000000000000000000000000000002).configureGovernor(msg.sender);
         _name = "Fantasy";
         _symbol = "FANTASY";
     }

--- a/src/Minter.sol
+++ b/src/Minter.sol
@@ -66,12 +66,8 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
         uint256 _cardsRequiredForBurnToDraw,
         uint256 _cardsDrawnPerBurn
     ) AccessControlDefaultAdminRules(0, msg.sender) {
-        // REVIEW: When this contract is live
-        // IBlast(0x4300000000000000000000000000000000000002)
-        //     .configureClaimableGas();
-        // IBlast(0x4300000000000000000000000000000000000002).configureGovernor(
-        //     msg.sender
-        // );
+        IBlast(0x4300000000000000000000000000000000000002).configureClaimableGas();
+        IBlast(0x4300000000000000000000000000000000000002).configureGovernor(msg.sender);
         _setTreasury(_treasury);
         _setExecutionDelegate(_executionDelegate);
         _setcardsRequiredForLevelUp(_cardsRequiredForLevelUp);

--- a/test/base/BaseTest.t.sol
+++ b/test/base/BaseTest.t.sol
@@ -9,6 +9,7 @@ import {Exchange} from "../../src/Exchange.sol";
 import {ExecutionDelegate} from "../../src/ExecutionDelegate.sol";
 import {Minter} from "../../src/Minter.sol";
 import {WrappedETH} from "../tokens/WrappedETH.sol";
+import {BlastMock} from "../helpers/BlastMock.sol";
 
 abstract contract BaseTest is Test {
     CheatCodes constant cheats = CheatCodes(HEVM_ADDRESS);
@@ -73,14 +74,19 @@ abstract contract BaseTest is Test {
         fantasyCards.grantRole(fantasyCards.EXECUTION_DELEGATE_ROLE(), _executionDelegate);
     }
 
+    function deployBlastMock() internal {
+        BlastMock blastMock = new BlastMock();
+        vm.etch(0x4300000000000000000000000000000000000002, address(blastMock).code);
+    }
+
     function setUp() public virtual {
+        deployBlastMock();
         deployFantasyCards();
         deployExecutionDelegate();
         deployWETH();
         setUpMinter(treasury, address(executionDelegate));
         setUpExchange(treasury, protocolFeeBps, address(executionDelegate), address(weth), address(fantasyCards));
         setUpExecutionDelegate(address(minter), address(exchange));
-        // setUpExecutionDelegate(address(minterVRGDA), address(exchange));
         setUpFantasyCards(address(executionDelegate));
     }
 }

--- a/test/helpers/BlastMock.sol
+++ b/test/helpers/BlastMock.sol
@@ -1,0 +1,7 @@
+pragma solidity 0.8.20;
+
+contract BlastMock {
+    function configureClaimableGas() external {}
+
+    function configureGovernor(address sender) external {}
+}


### PR DESCRIPTION
Added blast mock deployment to baseTest so we can uncomment function calls to the blast contract in the constructor of  every fantasy contract.
Also fixed a typo in the script deploy_testnet