### PR TITLE
Issue 32

### DIFF
--- a/src/Exchange.sol
+++ b/src/Exchange.sol
@@ -371,7 +371,7 @@ contract Exchange is IExchange, EIP712, Ownable, ReentrancyGuard {
         require(whitelistedCollections[collection], "Collection is not withelisted");
 
         /* Call execution delegate. */
-        executionDelegate.transferERC721(collection, from, to, tokenId);
+        executionDelegate.transferERC721Unsafe(collection, from, to, tokenId);
     }
 
     /**


### PR DESCRIPTION
https://github.com/cantinasec/review-fantasy/issues/32

made the token transfer in the exchange unsafe, because contracts should not be trading cards anyway. It also reduces the "gas stealing" attack surface