### PR TITLE
Issue 26

### DIFF
--- a/src/libraries/OrderLib.sol
+++ b/src/libraries/OrderLib.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 library OrderLib {
     bytes32 public constant ORDER_TYPEHASH =


### PR DESCRIPTION
https://github.com/cantinasec/review-fantasy/issues/26

updated orderLib pragma to respect the good practice.

I did not update the contracts pragma to 0.8.23 because it is not compatible with OZ libraries being used