### PR TITLE
v1.1 Adding helper functions for batch operations

### DIFF
--- a/script/end2endForIndexer.s.sol
+++ b/script/end2endForIndexer.s.sol
@@ -103,7 +103,7 @@ contract End2endForIndexer is Script {
         vm.startBroadcast(user2PrivateKey);
         weth.getFaucet(sellOrder.price);
         weth.approve(address(executionDelegate), sellOrder.price);
-        exchange.buy(sellOrder, sellerSignature);
+        exchange.buy(sellOrder, sellerSignature, false);
         vm.stopBroadcast();
 
         // User1 bids on a card

--- a/src/Exchange.sol
+++ b/src/Exchange.sol
@@ -250,6 +250,7 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
      * @param minimuPrice The new minimum price
      */
     function setMinimumPricePerPaymentToken(address paymentToken, uint256 minimuPrice) public onlyOwner {
+        require(whitelistedPaymentTokens[paymentToken], "payment token not whitelisted");
         _setMinimumPricePerPaymentToken(paymentToken, minimuPrice);
     }
 

--- a/src/Exchange.sol
+++ b/src/Exchange.sol
@@ -299,6 +299,8 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
         cancelledOrFilled[sellOrderHash] = true;
 
         _executeFundsTransfer(msg.sender, sellOrder.trader, sellOrder.paymentToken, sellOrder.price);
+        
+        emit Buy(msg.sender, sellOrder, sellOrderHash);
 
         if (burnAfterPurchase) {
             executionDelegate.burnFantasyCard(sellOrder.collection, sellOrder.tokenId);
@@ -307,7 +309,6 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
             _executeTokenTransfer(sellOrder.collection, sellOrder.trader, msg.sender, sellOrder.tokenId);
         }
 
-        emit Buy(msg.sender, sellOrder, sellOrderHash);
     }
 
     /**

--- a/src/Exchange.sol
+++ b/src/Exchange.sol
@@ -304,8 +304,8 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
         emit Buy(msg.sender, sellOrder, sellOrderHash);
 
         if (burnAfterPurchase) {
-            require(whitelistedCollections[collection], "Collection is not whitelisted");
-            executionDelegate.burnFantasyCard(sellOrder.collection, sellOrder.tokenId);
+            require(whitelistedCollections[sellOrder.collection], "Collection is not whitelisted");
+            executionDelegate.burnFantasyCard(sellOrder.collection, sellOrder.tokenId, sellOrder.trader);
             emit BuyAndBurn(msg.sender, sellOrder, sellOrderHash);
         } else {
             _executeTokenTransfer(sellOrder.collection, sellOrder.trader, msg.sender, sellOrder.tokenId);

--- a/src/Exchange.sol
+++ b/src/Exchange.sol
@@ -142,17 +142,24 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
     }
 
     /**
-     * @notice Cancels an order, preventing it from being executed
+     * @notice Cancels an order, preventing it from being executed. Could use batchCancelOrders with array length 1 instead but keeping it for retrocompatibility
      * @dev Sets the order's hash in the `cancelledOrFilled` mapping to true
      * @param order The order to cancel
      */
     function cancelOrder(OrderLib.Order calldata order) public {
-        require(order.trader == msg.sender, "msg.sender is not the trader");
+        _cancelOrder(order);
+    }
 
-        bytes32 orderHash = OrderLib._hashOrder(order);
-        cancelledOrFilled[orderHash] = true;
 
-        emit CancelOrder(orderHash);
+    /**
+     * @notice Cancels multiple orders in a single transaction
+     * @dev Iterates through the list of orders and calls the internal _cancelOrder function for each order
+     * @param orders The array of orders to be cancelled
+     */
+    function batchCancelOrders(OrderLib.Order[] calldata orders) public {
+        for (uint256 i = 0; i < orders.length; i++) {
+            _cancelOrder(orders[i]);
+        }
     }
 
     /**
@@ -286,6 +293,20 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
         _executeTokenTransfer(sellOrder.collection, sellOrder.trader, msg.sender, sellOrder.tokenId);
 
         emit Buy(msg.sender, sellOrder, sellOrderHash);
+    }
+
+    /**
+     * @notice Internal function that cancels an order
+     * @dev Requires that the caller is the trader specified in the order. Marks the order as cancelled or filled and emits a CancelOrder event.
+     * @param order The order to be cancelled
+     */
+    function _cancelOrder(OrderLib.Order calldata order) internal {
+        require(order.trader == msg.sender, "msg.sender is not the trader");
+
+        bytes32 orderHash = OrderLib._hashOrder(order);
+        cancelledOrFilled[orderHash] = true;
+
+        emit CancelOrder(orderHash);
     }
 
     /**

--- a/src/Exchange.sol
+++ b/src/Exchange.sol
@@ -301,6 +301,7 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
         _executeFundsTransfer(msg.sender, sellOrder.trader, sellOrder.paymentToken, sellOrder.price);
 
         if (burnAfterPurchase) {
+            require(whitelistedCollections[collection], "Collection is not whitelisted");
             executionDelegate.burnFantasyCard(sellOrder.collection, sellOrder.tokenId);
         } else {
             _executeTokenTransfer(sellOrder.collection, sellOrder.trader, msg.sender, sellOrder.tokenId);

--- a/src/Exchange.sol
+++ b/src/Exchange.sol
@@ -79,6 +79,7 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
      * @dev Iterates over `sellOrders` and `sellerSignatures`, executing each through `_buy`.
      * @param sellOrders Array of sell orders, each following `OrderLib.Order` structure.
      * @param sellerSignatures Array of signatures, each corresponding to a sell order in `sellOrders`.
+     * @param burnAfterPurchase Whether to burn the NFT(s) after the purchase
      */
     function batchBuy(
         OrderLib.Order[] calldata sellOrders,
@@ -149,7 +150,8 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
     }
 
     /**
-     * @notice Cancels an order, preventing it from being executed. Could use batchCancelOrders with array length 1 instead but keeping it for retrocompatibility
+     * @notice Cancels an order, preventing it from being executed. This function is provided for backward compatibility and convenience, although similar functionality can be achieved using
+     * `batchCancelOrders` with an array containing a single order.
      * @dev Sets the order's hash in the `cancelledOrFilled` mapping to true
      * @param order The order to cancel
      */
@@ -159,7 +161,7 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
 
 
     /**
-     * @notice Cancels multiple orders in a single transaction
+     * @notice Cancels multiple orders in a single transaction to save gas and streamline order management.
      * @dev Iterates through the list of orders and calls the internal _cancelOrder function for each order
      * @param orders The array of orders to be cancelled
      */

--- a/src/Exchange.sol
+++ b/src/Exchange.sol
@@ -302,6 +302,7 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
 
         if (burnAfterPurchase) {
             executionDelegate.burnFantasyCard(sellOrder.collection, sellOrder.tokenId);
+            emit BuyAndBurn(msg.sender, sellOrder, sellOrderHash);
         } else {
             _executeTokenTransfer(sellOrder.collection, sellOrder.trader, msg.sender, sellOrder.tokenId);
         }

--- a/src/Exchange.sol
+++ b/src/Exchange.sol
@@ -83,7 +83,7 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
     function batchBuy(
         OrderLib.Order[] calldata sellOrders,
         bytes[] calldata sellerSignatures,
-        bool[] calldata burnAfterPurchase
+        bool burnAfterPurchase
     ) public payable nonReentrant onlyEOA {
         require(sellOrders.length == sellerSignatures.length, "Array length mismatch");
 
@@ -95,10 +95,14 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
                 totalEthSpending += sellOrders[i].price;
                 require(totalEthSpending <= msg.value, "Insufficient ETH sent");
             }
-            _buy(sellOrders[i], sellerSignatures[i], burnAfterPurchase[i]);
+            _buy(sellOrders[i], sellerSignatures[i], burnAfterPurchase);
         }
 
-        emit BatchBuy(msg.sender, sellOrders, sellerSignatures);
+        if (burnAfterPurchase) {
+            emit BatchBuyAndBurn(msg.sender, sellOrders, sellerSignatures);
+        } else {
+            emit BatchBuy(msg.sender, sellOrders, sellerSignatures);
+        }
     }
 
     /**

--- a/src/Exchange.sol
+++ b/src/Exchange.sol
@@ -304,6 +304,7 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
         emit Buy(msg.sender, sellOrder, sellOrderHash);
 
         if (burnAfterPurchase) {
+            require(whitelistedCollections[collection], "Collection is not whitelisted");
             executionDelegate.burnFantasyCard(sellOrder.collection, sellOrder.tokenId);
             emit BuyAndBurn(msg.sender, sellOrder, sellOrderHash);
         } else {

--- a/src/Exchange.sol
+++ b/src/Exchange.sol
@@ -301,7 +301,7 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
         _executeFundsTransfer(msg.sender, sellOrder.trader, sellOrder.paymentToken, sellOrder.price);
 
         if (burnAfterPurchase) {
-            executionDelegate.burnFantasyCard(sellOrder.collection, sellOrder.tokenId);
+            executionDelegate.burnFantasyCard(sellOrder.collection, sellOrder.tokenId, sellOrder.trader);
         } else {
             _executeTokenTransfer(sellOrder.collection, sellOrder.trader, msg.sender, sellOrder.tokenId);
         }

--- a/src/Exchange.sol
+++ b/src/Exchange.sol
@@ -300,14 +300,16 @@ contract Exchange is IExchange, EIP712, Ownable2Step, ReentrancyGuard {
         cancelledOrFilled[sellOrderHash] = true;
 
         _executeFundsTransfer(msg.sender, sellOrder.trader, sellOrder.paymentToken, sellOrder.price);
+        
+        emit Buy(msg.sender, sellOrder, sellOrderHash);
 
         if (burnAfterPurchase) {
             executionDelegate.burnFantasyCard(sellOrder.collection, sellOrder.tokenId);
+            emit BuyAndBurn(msg.sender, sellOrder, sellOrderHash);
         } else {
             _executeTokenTransfer(sellOrder.collection, sellOrder.trader, msg.sender, sellOrder.tokenId);
         }
 
-        emit Buy(msg.sender, sellOrder, sellOrderHash);
     }
 
     /**

--- a/src/ExecutionDelegate.sol
+++ b/src/ExecutionDelegate.sol
@@ -88,7 +88,8 @@ contract ExecutionDelegate is IExecutionDelegate, AccessControlDefaultAdminRules
         IFantasyCards(collection).safeMint(to);
     }
 
-    function burnFantasyCard(address collection, uint256 tokenId) external whenNotPaused approvedContract {
+    function burnFantasyCard(address collection, uint256 tokenId, address from) external whenNotPaused approvedContract {
+        require(revokedApproval[from] == false, "User has revoked approval");
         IFantasyCards(collection).burn(tokenId);
     }
 

--- a/src/Minter.sol
+++ b/src/Minter.sol
@@ -227,6 +227,7 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
         uint256 startTimestamp,
         uint256 expirationTimestamp
     ) public onlyRole(MINT_CONFIG_MASTER) {
+        require(whitelistedCollections[collection], "Collection is not whitelisted");
         require(collection != address(0), "Collection address cannot be 0x0");
         require(cardsPerPack > 0, "Cards per pack must be greater than 0");
         require(maxPacks > 0, "Max packs must be greater than 0");
@@ -394,6 +395,7 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
      * @param collection The new collection address
      */
     function setCollectionForMintConfig(uint256 mintConfigId, address collection) public onlyRole(MINT_CONFIG_MASTER) {
+        require(whitelistedCollections[collection], "Collection is not whitelisted");
         require(mintConfigId < mintConfigIdCounter, "Invalid mintConfigId");
         require(collection != address(0), "Collection address cannot the zero address");
 

--- a/src/Minter.sol
+++ b/src/Minter.sol
@@ -147,8 +147,8 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
      * @param recipients Addresses to mint packs to
      */
     function batchMintCardsTo(uint256 configId, bytes32[][] calldata merkleProofs, uint256 maxPrice, address[] calldata recipients) public payable nonReentrant onlyEOA onlyRole(MINT_CONFIG_MASTER) {
+        require(merkleProofs.length == recipients.length, "merkleProofs length mismatch");
         for (uint i = 0; i < recipients.length; i++) {
-            require(merkleProofs[i].length == recipients.length, "merkleProofs length mismatch");
             _mintCardsTo(configId, merkleProofs[i], maxPrice, recipients[i]);
         }
     }
@@ -309,7 +309,7 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
                 IFantasyCards(collection).ownerOf(tokenIds[i]) == msg.sender,
                 "caller does not own one of the tokens"
             );
-            executionDelegate.burnFantasyCard(address(collection), tokenIds[i]);
+            executionDelegate.burnFantasyCard(address(collection), tokenIds[i], msg.sender);
         }
 
         uint256 mintedTokenId = IFantasyCards(collection).tokenCounter();
@@ -354,7 +354,7 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
                 IFantasyCards(collection).ownerOf(tokenIds[i]) == msg.sender,
                 "caller does not own one of the tokens"
             );
-            executionDelegate.burnFantasyCard(address(collection), tokenIds[i]);
+            executionDelegate.burnFantasyCard(address(collection), tokenIds[i], msg.sender);
         }
 
         uint256[] memory drawnCardIds = new uint256[](cardsDrawnPerBurn);
@@ -381,9 +381,7 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
         // check that the caller owns all the tokens
         for (uint i = 0; i < tokenIds.length; i++) {
             require(IFantasyCards(collection).ownerOf(tokenIds[i]) == msg.sender, "caller does not own one of the tokens");
-        }
-        for (uint i = 0; i < tokenIds.length; i++) {
-            executionDelegate.burnFantasyCard(address(collection), tokenIds[i]);
+            executionDelegate.burnFantasyCard(address(collection), tokenIds[i], msg.sender);
         }
         emit BatchBurn(tokenIds, collection, msg.sender);
     }

--- a/src/Minter.sol
+++ b/src/Minter.sol
@@ -228,6 +228,7 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
         uint256 startTimestamp,
         uint256 expirationTimestamp
     ) public onlyRole(MINT_CONFIG_MASTER) {
+        require(whitelistedCollections[collection], "Collection is not whitelisted");
         require(collection != address(0), "Collection address cannot be 0x0");
         require(cardsPerPack > 0, "Cards per pack must be greater than 0");
         require(maxPacks > 0, "Max packs must be greater than 0");
@@ -395,6 +396,7 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
      * @param collection The new collection address
      */
     function setCollectionForMintConfig(uint256 mintConfigId, address collection) public onlyRole(MINT_CONFIG_MASTER) {
+        require(whitelistedCollections[collection], "Collection is not whitelisted");
         require(mintConfigId < mintConfigIdCounter, "Invalid mintConfigId");
         require(collection != address(0), "Collection address cannot the zero address");
 

--- a/src/Minter.sol
+++ b/src/Minter.sol
@@ -148,6 +148,7 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
      */
     function batchMintCardsTo(uint256 configId, bytes32[][] calldata merkleProofs, uint256 maxPrice, address[] calldata recipients) public payable nonReentrant onlyEOA onlyRole(MINT_CONFIG_MASTER) {
         for (uint i = 0; i < recipients.length; i++) {
+            require(merkleProofs[i].length == recipients.length, "merkleProofs length mismatch");
             _mintCardsTo(configId, merkleProofs[i], maxPrice, recipients[i]);
         }
     }

--- a/src/Minter.sol
+++ b/src/Minter.sol
@@ -142,13 +142,13 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
      * @notice Admin function to mints packs based on the specified mint configuration to multiple recipients
      * @dev Requires the mint configuration not to be cancelled, the user to be whitelisted (if applicable), and not to have minted before (if applicable). Transfers the payment and mints the NFTs.
      * @param configId ID of the mint configuration to use
-     * @param merkleProof Proof for whitelist verification, if required
+     * @param merkleProofs Proofs for whitelist verifications, if required
      * @param maxPrice Maximum price the user is willing to pay
      * @param recipients Addresses to mint packs to
      */
-    function batchMintCardsTo(uint256 configId, bytes32[] calldata merkleProof, uint256 maxPrice, address[] calldata recipients) public payable nonReentrant onlyEOA onlyRole(MINT_CONFIG_MASTER) {
+    function batchMintCardsTo(uint256 configId, bytes32[][] calldata merkleProofs, uint256 maxPrice, address[] calldata recipients) public payable nonReentrant onlyEOA onlyRole(MINT_CONFIG_MASTER) {
         for (uint i = 0; i < recipients.length; i++) {
-            _mintCardsTo(configId, merkleProof, maxPrice, recipients[i]);
+            _mintCardsTo(configId, merkleProofs[i], maxPrice, recipients[i]);
         }
     }
 

--- a/src/Minter.sol
+++ b/src/Minter.sol
@@ -97,49 +97,11 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
         bytes32[] calldata merkleProof,
         uint256 maxPrice
     ) public payable nonReentrant onlyEOA {
-        MintConfig storage mintConfig = mintConfigs[configId];
-        require(mintConfig.startTimestamp <= block.timestamp, "Mint config not started");
-        require(
-            mintConfig.expirationTimestamp == 0 || mintConfig.expirationTimestamp > block.timestamp,
-            "Mint config expired"
-        );
-        require(!mintConfig.cancelled, "Mint config cancelled");
-        require(
-            !mintConfig.requiresWhitelist || _verifyWhitelist(mintConfig.merkleRoot, merkleProof, msg.sender),
-            "User not whitelisted"
-        );
-        require(
-            mintConfig.maxPacksPerAddress == 0 ||
-                mintConfig.amountMintedPerAddress[msg.sender] < mintConfig.maxPacksPerAddress,
-            "User reached max mint limit"
-        );
-        require(mintConfig.maxPacks > mintConfig.totalMintedPacks, "No packs left");
-
-        // compute the price before incrementing the total packs minted since it will push the price up otherwise
-        uint256 price = getPackPrice(configId);
-        require(price <= maxPrice, "Price too high");
-
-        mintConfig.totalMintedPacks += 1;
-        mintConfig.amountMintedPerAddress[msg.sender] += 1;
-
-        _executeFundsTransfer(mintConfig.paymentToken, msg.sender, treasury, price);
-
-        uint256 firstTokenId = IFantasyCards(mintConfig.collection).tokenCounter();
-
-        _executeBatchMint(mintConfig.collection, mintConfig.cardsPerPack, msg.sender);
-
-        emit Mint(
-            configId,
-            msg.sender,
-            mintConfig.totalMintedPacks,
-            firstTokenId,
-            firstTokenId + mintConfig.cardsPerPack - 1,
-            price
-        );
+      _mint(configId, merkleProof, maxPrice, msg.sender);
     }
 
     /**
-     * @notice Admin function to mints packs based on the specified mint configuration to multiple recipients
+     * @notice Admin function to mint packs based on the specified mint configuration to multiple recipients
      * @dev Requires the mint configuration not to be cancelled, the user to be whitelisted (if applicable), and not to have minted before (if applicable). Transfers the payment and mints the NFTs.
      * @param configId ID of the mint configuration to use
      * @param merkleProofs Proofs for whitelist verifications, if required
@@ -149,18 +111,18 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
     function batchMintCardsTo(uint256 configId, bytes32[][] calldata merkleProofs, uint256 maxPrice, address[] calldata recipients) public payable nonReentrant onlyEOA onlyRole(MINT_CONFIG_MASTER) {
         require(merkleProofs.length == recipients.length, "merkleProofs length mismatch");
         for (uint i = 0; i < recipients.length; i++) {
-            _mintCardsTo(configId, merkleProofs[i], maxPrice, recipients[i]);
+            _mint(configId, merkleProofs[i], maxPrice, recipients[i]);
         }
     }
 
     /**
-     * @dev Internal function to mint packs based on the specified mint configuration to a single recipient. This function is a very close cousin of the mint function.
+     * @dev Internal function to mint packs based on the specified mint configuration to a single recipient.
      * @param configId ID of the mint configuration to use
      * @param merkleProof Proof for whitelist verification, if required
      * @param maxPrice Maximum price the user is willing to pay
      * @param recipient Address to mint packs to
      */
-    function _mintCardsTo(uint256 configId, bytes32[] calldata merkleProof, uint256 maxPrice, address recipient) internal {
+    function _mint(uint256 configId, bytes32[] calldata merkleProof, uint256 maxPrice, address recipient) internal {
         MintConfig storage mintConfig = mintConfigs[configId];
         require(mintConfig.startTimestamp <= block.timestamp, "Mint config not started");
         require(

--- a/src/Minter.sol
+++ b/src/Minter.sol
@@ -307,7 +307,7 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
                 IFantasyCards(collection).ownerOf(tokenIds[i]) == msg.sender,
                 "caller does not own one of the tokens"
             );
-            executionDelegate.burnFantasyCard(address(collection), tokenIds[i]);
+            executionDelegate.burnFantasyCard(address(collection), tokenIds[i], msg.sender);
         }
 
         uint256 mintedTokenId = IFantasyCards(collection).tokenCounter();
@@ -352,7 +352,7 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
                 IFantasyCards(collection).ownerOf(tokenIds[i]) == msg.sender,
                 "caller does not own one of the tokens"
             );
-            executionDelegate.burnFantasyCard(address(collection), tokenIds[i]);
+            executionDelegate.burnFantasyCard(address(collection), tokenIds[i], msg.sender);
         }
 
         uint256[] memory drawnCardIds = new uint256[](cardsDrawnPerBurn);
@@ -379,9 +379,7 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
         // check that the caller owns all the tokens
         for (uint i = 0; i < tokenIds.length; i++) {
             require(IFantasyCards(collection).ownerOf(tokenIds[i]) == msg.sender, "caller does not own one of the tokens");
-        }
-        for (uint i = 0; i < tokenIds.length; i++) {
-            executionDelegate.burnFantasyCard(address(collection), tokenIds[i]);
+            executionDelegate.burnFantasyCard(address(collection), tokenIds[i], msg.sender);
         }
         emit BatchBurn(tokenIds, collection, msg.sender);
     }

--- a/src/Minter.sol
+++ b/src/Minter.sol
@@ -317,12 +317,33 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
     }
 
     /**
-     * @notice Allows a user to burn their hero cards to draw new random cards
-     * @dev Burns the specified amount of cards (tokens) to draw (a) new card(s). The burnToDraw happens at the metadata level. Using this method directly might result in loss of cards if the cards do not meet the game rules.
-     * @param tokenIds An array of token IDs representing the cards to be burned
+     * @notice Allows a user to burn their hero cards to draw new random cards. This function is provided for backward compatibility and convenience, although similar functionality can be achieved using
+     * `batchBurnToDraw` with an array containing a single burn.
+     * @dev Burns the specified amount of cards to draw new cards. The burnToDraw happens at the metadata level. Using this method directly might result in loss of cards if the cards do not meet the game rules.
+     * @param tokenIds An array of token IDs representing the cards to be burned.
      * @param collection The address of the NFT collection from which the cards will be burned and the new card(s) will be minted.
      */
     function burnToDraw(uint256[] calldata tokenIds, address collection) public {
+       _burnToDraw(tokenIds, collection);
+    }
+
+    /**
+     * @notice Allows a user to burn multiple sets of cards to draw new cards
+     * @param tokenIds An array of token IDs arrays representing the cards to be burned. Each internal array represents a different burn.
+     * @param collection The address of the NFT collection from which the cards will be burned and the new card(s) will be minted.
+     */
+    function batchBurnToDraw(uint256[][] calldata tokenIds, address collection) public {
+        for (uint i = 0; i < tokenIds.length; i++) {
+            _burnToDraw(tokenIds[i], collection);
+        }
+    }
+
+    /**
+     * @dev Internal function to burn cards to draw new cards
+     * @param tokenIds An array of token IDs representing the cards to be burned
+     * @param collection The address of the NFT collection from which the cards will be burned and the new card(s) will be minted.
+    */
+    function _burnToDraw(uint256[] calldata tokenIds, address collection) internal {
         require(whitelistedCollections[collection], "Collection is not whitelisted");
         require(tokenIds.length == cardsRequiredForBurnToDraw, "wrong amount of cards to draw new cards");
 

--- a/src/Minter.sol
+++ b/src/Minter.sol
@@ -282,6 +282,27 @@ contract Minter is IMinter, AccessControlDefaultAdminRules, ReentrancyGuard, Lin
         emit BurnToDraw(tokenIds, drawnCardIds, collection, msg.sender);
     }
 
+
+    /**
+     * @notice Burns multiple cards in a single transaction
+     * @dev Iterates through the list of tokenIds and burns each one
+     * @param collection The address of the collection from which the cards will be burned
+     * @param tokenIds The array of tokenIds to be burned
+     */
+    function batchBurn(address collection, uint256[] calldata tokenIds) public {
+        require(tokenIds.length > 0, "no tokens to burn");
+        require(whitelistedCollections[collection], "Collection is not whitelisted");
+        // check that the caller owns all the tokens
+        for (uint i = 0; i < tokenIds.length; i++) {
+            require(IFantasyCards(collection).ownerOf(tokenIds[i]) == msg.sender, "caller does not own one of the tokens");
+        }
+        for (uint i = 0; i < tokenIds.length; i++) {
+            executionDelegate.burnFantasyCard(address(collection), tokenIds[i]);
+        }
+        emit BatchBurn(tokenIds, collection, msg.sender);
+    }
+
+
     /**
      * @notice Updates the NFT collection address for a specific mint configuration
      * @dev Only callable by the contract owner.

--- a/src/interfaces/IExchange.sol
+++ b/src/interfaces/IExchange.sol
@@ -6,6 +6,7 @@ import "../libraries/OrderLib.sol";
 interface IExchange {
     /* Events */
     event Buy(address indexed buyer, OrderLib.Order sell, bytes32 sellOrderHash);
+    event BuyAndBurn(address indexed buyer, OrderLib.Order sell, bytes32 sellOrderHash);
     event Sell(address indexed seller, OrderLib.Order buyOrder, uint256 tokenId, bytes32 buyOrderHash);
     event BatchBuy(address indexed buyer, OrderLib.Order[] sellOrders, bytes[] sellerSignatures);
     event BatchBuyAndBurn(address indexed buyer, OrderLib.Order[] sellOrders, bytes[] sellerSignatures);

--- a/src/interfaces/IExchange.sol
+++ b/src/interfaces/IExchange.sol
@@ -7,6 +7,8 @@ interface IExchange {
     /* Events */
     event Buy(address indexed buyer, OrderLib.Order sell, bytes32 sellOrderHash);
     event Sell(address indexed seller, OrderLib.Order buyOrder, uint256 tokenId, bytes32 buyOrderHash);
+    event BatchBuy(address indexed buyer, OrderLib.Order[] sellOrders, bytes[] sellerSignatures);
+    event BatchSell(address indexed seller, OrderLib.Order[] buyOrders, uint256[] tokenIds, bytes32[][] merkleProofs);
     event CancelOrder(bytes32 orderHash);
     event NewWhitelistedPaymentToken(address paymentToken);
     event UnWhitelistedPaymentToken(address paymentToken);

--- a/src/interfaces/IExchange.sol
+++ b/src/interfaces/IExchange.sol
@@ -8,6 +8,7 @@ interface IExchange {
     event Buy(address indexed buyer, OrderLib.Order sell, bytes32 sellOrderHash);
     event Sell(address indexed seller, OrderLib.Order buyOrder, uint256 tokenId, bytes32 buyOrderHash);
     event BatchBuy(address indexed buyer, OrderLib.Order[] sellOrders, bytes[] sellerSignatures);
+    event BatchBuyAndBurn(address indexed buyer, OrderLib.Order[] sellOrders, bytes[] sellerSignatures);
     event BatchSell(address indexed seller, OrderLib.Order[] buyOrders, uint256[] tokenIds, bytes32[][] merkleProofs);
     event CancelOrder(bytes32 orderHash);
     event NewWhitelistedPaymentToken(address paymentToken);

--- a/src/interfaces/IExchange.sol
+++ b/src/interfaces/IExchange.sol
@@ -20,7 +20,7 @@ interface IExchange {
     event NewMinimumPricePerPaymentToken(address paymentToken, uint256 minimuPrice);
 
     /* Functions */
-    function buy(OrderLib.Order calldata sellOrder, bytes calldata sellerSignature) external payable;
+    function buy(OrderLib.Order calldata sellOrder, bytes calldata sellerSignature, bool burnAfterPurchase) external payable;
 
     function sell(
         OrderLib.Order calldata buyOrder,

--- a/src/interfaces/IExecutionDelegate.sol
+++ b/src/interfaces/IExecutionDelegate.sol
@@ -18,7 +18,7 @@ interface IExecutionDelegate {
 
     function mintFantasyCard(address collection, address to) external;
 
-    function burnFantasyCard(address collection, uint256 tokenId) external;
+    function burnFantasyCard(address collection, uint256 tokenId, address from) external;
 
     function transferERC721Unsafe(address collection, address from, address to, uint256 tokenId) external;
 

--- a/src/interfaces/IMinter.sol
+++ b/src/interfaces/IMinter.sol
@@ -33,6 +33,7 @@ interface IMinter {
     );
     event LevelUp(uint256[] burntTokenIds, uint256 mintedTokenId, address collection, address caller);
     event BurnToDraw(uint256[] burntTokenIds, uint256[] mintedTokenIds, address collection, address caller);
+    event BatchBurn(uint256[] burntTokenIds, address collection, address caller);
     event NewTreasury(address treasury);
     event NewExecutionDelegate(address _executionDelegate);
     event CollectionUpdatedForMintConfig(uint256 mintConfigId, address newCollection);

--- a/test/base/BaseTest.t.sol
+++ b/test/base/BaseTest.t.sol
@@ -29,13 +29,15 @@ abstract contract BaseTest is Test {
     uint256 mintConfigMasterPrivateKey = 0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97;
     uint256 user1PrivateKey = 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a;
     uint256 user2PrivateKey = 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6;
-
+    uint256 user3PrivateKey = 0x47e17f898ffc4d5f763548ea3b3cf9bb1230d213d0a008a1d4775c66c71f4767;
+    
     address deployer = vm.addr(deployerPrivateKey);
     address treasury = vm.addr(treasuryPrivateKey);
     address pauserAndCanceler = vm.addr(pauserAndCancelerPrivateKey);
     address mintConfigMaster = vm.addr(mintConfigMasterPrivateKey);
     address user1 = vm.addr(user1PrivateKey);
     address user2 = vm.addr(user2PrivateKey);
+    address user3 = vm.addr(user3PrivateKey);
 
     uint256 protocolFeeBps = 300;
     uint256 cardsRequiredForLevelUp = 5;

--- a/test/exchange/batchBuy.t.sol
+++ b/test/exchange/batchBuy.t.sol
@@ -70,7 +70,7 @@ contract Buy is BaseTest {
 
         // Execute buy
         cheats.startPrank(user2, user2);
-        exchange.batchBuy{value: totalPrice}(sellOrders, sellerSignatures, new bool[](sellOrders.length));
+        exchange.batchBuy{value: totalPrice}(sellOrders, sellerSignatures, false);
         cheats.stopPrank();
 
         assertEq(treasury.balance, (totalPrice * exchange.protocolFeeBps()) / exchange.INVERSE_BASIS_POINT());
@@ -134,7 +134,7 @@ contract Buy is BaseTest {
 
         // Execute buy
         cheats.startPrank(user2, user2);
-        exchange.batchBuy(sellOrders, sellerSignatures, new bool[](sellOrders.length));
+        exchange.batchBuy(sellOrders, sellerSignatures, false);
         cheats.stopPrank();
 
         assertEq(weth.balanceOf(treasury), (totalPrice * exchange.protocolFeeBps()) / exchange.INVERSE_BASIS_POINT());
@@ -198,7 +198,7 @@ contract Buy is BaseTest {
 
         // Execute buy
         cheats.startPrank(user2, user2);
-        exchange.batchBuy{value: 1 ether}(sellOrders, sellerSignatures, new bool[](sellOrders.length));
+        exchange.batchBuy{value: 1 ether}(sellOrders, sellerSignatures, false);
         cheats.stopPrank();
 
         assertEq(treasury.balance, (1 ether * exchange.protocolFeeBps()) / exchange.INVERSE_BASIS_POINT());
@@ -262,7 +262,7 @@ contract Buy is BaseTest {
         // Execute buy
         cheats.startPrank(user2, user2);
         cheats.expectRevert("Insufficient ETH sent");
-        exchange.batchBuy{value: totalPrice - 1}(sellOrders, sellerSignatures, new bool[](sellOrders.length));
+        exchange.batchBuy{value: totalPrice - 1}(sellOrders, sellerSignatures, false);
         cheats.stopPrank();
     }
 
@@ -321,7 +321,7 @@ contract Buy is BaseTest {
         // Execute buy
         cheats.startPrank(user2, user2);
         cheats.expectRevert(); // REVIEW: proper error message
-        exchange.batchBuy(sellOrders, sellerSignatures, new bool[](sellOrders.length));
+        exchange.batchBuy(sellOrders, sellerSignatures, false);
         cheats.stopPrank();
     }
 
@@ -346,153 +346,7 @@ contract Buy is BaseTest {
         // Execute buy
         cheats.startPrank(user2, user2);
         cheats.expectRevert("Array length mismatch");
-        exchange.batchBuy(sellOrders, sellerSignatures, new bool[](sellOrders.length));
+        exchange.batchBuy(sellOrders, sellerSignatures, false);
         cheats.stopPrank();
-    }
-
-    function test_successful_batchBuy_ETH_with_mixed_burns() public {
-        // Create first sell order
-        OrderLib.Order memory sellOrder1 = OrderLib.Order(
-            user1,
-            OrderLib.Side.Sell,
-            address(fantasyCards),
-            0,
-            address(0),
-            1 ether,
-            999999999999999999999,
-            bytes32(0),
-            100_001
-        );
-
-        // Sign order
-        bytes32 orderHash1 = HashLib.getTypedDataHash(sellOrder1, exchange.domainSeparator());
-        (uint8 vSeller1, bytes32 rSeller1, bytes32 sSeller1) = vm.sign(user1PrivateKey, orderHash1);
-        bytes memory sellerSignature1 = abi.encodePacked(rSeller1, sSeller1, vSeller1);
-
-        // Create second sell order
-        OrderLib.Order memory sellOrder2 = OrderLib.Order(
-            user1,
-            OrderLib.Side.Sell,
-            address(fantasyCards),
-            1,
-            address(0),
-            2 ether,
-            999999999999999999999,
-            bytes32(0),
-            100_001
-        );
-
-        // Sign order
-        bytes32 orderHash2 = HashLib.getTypedDataHash(sellOrder2, exchange.domainSeparator());
-        (uint8 vSeller2, bytes32 rSeller2, bytes32 sSeller2) = vm.sign(user1PrivateKey, orderHash2);
-        bytes memory sellerSignature2 = abi.encodePacked(rSeller2, sSeller2, vSeller2);
-
-        uint256 totalPrice = sellOrder1.price + sellOrder2.price;
-
-        cheats.deal(user2, totalPrice);
-
-        OrderLib.Order[] memory sellOrders = new OrderLib.Order[](2);
-        sellOrders[0] = sellOrder1;
-        sellOrders[1] = sellOrder2;
-        bytes[] memory sellerSignatures = new bytes[](2);
-        sellerSignatures[0] = sellerSignature1;
-        sellerSignatures[1] = sellerSignature2;
-        
-        bool[] memory burnFlags = new bool[](2);
-        burnFlags[0] = true;  // Burn first NFT
-        burnFlags[1] = false; // Keep second NFT
-
-        // Execute buy
-        cheats.startPrank(user2, user2);
-        exchange.batchBuy{value: totalPrice}(sellOrders, sellerSignatures, burnFlags);
-        cheats.stopPrank();
-
-        // Check balances
-        assertEq(treasury.balance, (totalPrice * exchange.protocolFeeBps()) / exchange.INVERSE_BASIS_POINT());
-        assertEq(user1.balance, totalPrice - treasury.balance);
-        assertEq(user2.balance, 0);
-        assertEq(fantasyCards.balanceOf(user1), 0);
-        // User2 should only have the second NFT
-        assertEq(fantasyCards.balanceOf(user2), 1);
-        // Verify first token was burned - using correct error encoding
-        vm.expectRevert(abi.encodeWithSignature("ERC721NonexistentToken(uint256)", 0));
-        fantasyCards.ownerOf(0);
-        // Verify second token exists and belongs to user2
-        assertEq(fantasyCards.ownerOf(1), user2);
-    }
-
-    function test_successful_batchBuy_WETH_with_all_burns() public {
-        // Create first sell order
-        OrderLib.Order memory sellOrder1 = OrderLib.Order(
-            user1,
-            OrderLib.Side.Sell,
-            address(fantasyCards),
-            0,
-            address(weth),
-            1 ether,
-            999999999999999999999,
-            bytes32(0),
-            100_001
-        );
-
-        // Sign order
-        bytes32 orderHash1 = HashLib.getTypedDataHash(sellOrder1, exchange.domainSeparator());
-        (uint8 vSeller1, bytes32 rSeller1, bytes32 sSeller1) = vm.sign(user1PrivateKey, orderHash1);
-        bytes memory sellerSignature1 = abi.encodePacked(rSeller1, sSeller1, vSeller1);
-
-        // Create second sell order
-        OrderLib.Order memory sellOrder2 = OrderLib.Order(
-            user1,
-            OrderLib.Side.Sell,
-            address(fantasyCards),
-            1,
-            address(weth),
-            2 ether,
-            999999999999999999999,
-            bytes32(0),
-            100_001
-        );
-
-        // Sign order
-        bytes32 orderHash2 = HashLib.getTypedDataHash(sellOrder2, exchange.domainSeparator());
-        (uint8 vSeller2, bytes32 rSeller2, bytes32 sSeller2) = vm.sign(user1PrivateKey, orderHash2);
-        bytes memory sellerSignature2 = abi.encodePacked(rSeller2, sSeller2, vSeller2);
-
-        uint256 totalPrice = sellOrder1.price + sellOrder2.price;
-
-        // Give WETH allowance
-        cheats.startPrank(user2);
-        weth.getFaucet(totalPrice);
-        weth.approve(address(executionDelegate), totalPrice);
-        cheats.stopPrank();
-
-        OrderLib.Order[] memory sellOrders = new OrderLib.Order[](2);
-        sellOrders[0] = sellOrder1;
-        sellOrders[1] = sellOrder2;
-        bytes[] memory sellerSignatures = new bytes[](2);
-        sellerSignatures[0] = sellerSignature1;
-        sellerSignatures[1] = sellerSignature2;
-        
-        bool[] memory burnFlags = new bool[](2);
-        burnFlags[0] = true;
-        burnFlags[1] = true;
-
-        // Execute buy
-        cheats.startPrank(user2, user2);
-        exchange.batchBuy(sellOrders, sellerSignatures, burnFlags);
-        cheats.stopPrank();
-
-        // Check balances
-        assertEq(weth.balanceOf(treasury), (totalPrice * exchange.protocolFeeBps()) / exchange.INVERSE_BASIS_POINT());
-        assertEq(weth.balanceOf(user1), totalPrice - weth.balanceOf(treasury));
-        assertEq(weth.balanceOf(user2), 0);
-        assertEq(fantasyCards.balanceOf(user1), 0);
-        // User2 should have no NFTs as they were all burned
-        assertEq(fantasyCards.balanceOf(user2), 0);
-        // Verify both tokens were burned - using correct error encoding
-        vm.expectRevert(abi.encodeWithSignature("ERC721NonexistentToken(uint256)", 0));
-        fantasyCards.ownerOf(0);
-        vm.expectRevert(abi.encodeWithSignature("ERC721NonexistentToken(uint256)", 1));
-        fantasyCards.ownerOf(1);
     }
 }

--- a/test/exchange/batchCancelOrders.t.sol
+++ b/test/exchange/batchCancelOrders.t.sol
@@ -1,0 +1,59 @@
+pragma solidity ^0.8.20;
+
+import "../base/BaseTest.t.sol";
+import "../../src/libraries/OrderLib.sol";
+
+contract BatchCancelOrders is BaseTest {
+    OrderLib.Order[] orders;
+
+    function setUp() public override {
+        super.setUp();
+
+        OrderLib.Order memory order1 = OrderLib.Order(
+            user1,
+            OrderLib.Side.Sell,
+            address(fantasyCards),
+            0,
+            address(weth),
+            1 ether,
+            999999999999999999999,
+            bytes32(0),
+            0
+        );
+
+        OrderLib.Order memory order2 = OrderLib.Order(
+            user1,
+            OrderLib.Side.Sell,
+            address(fantasyCards),
+            0,
+            address(weth),
+            2 ether,
+            999999999999999999999,
+            bytes32(0),
+            0
+        );
+
+        orders.push(order1);
+        orders.push(order2);
+    }
+
+    function test_successful_batchCancelOrder() public {
+        // cancel order
+        cheats.startPrank(user1);
+        exchange.batchCancelOrders(orders);
+        cheats.stopPrank();
+
+        bytes32 orderHash0 = OrderLib._hashOrder(orders[0]);
+        bytes32 orderHash1 = OrderLib._hashOrder(orders[1]);
+
+        assertEq(exchange.cancelledOrFilled(orderHash0), true);
+        assertEq(exchange.cancelledOrFilled(orderHash1), true);
+    }
+
+    function test_unsuccessful_batchCancelOrder_wrong_trader() public {
+        cheats.startPrank(user2);
+        cheats.expectRevert("msg.sender is not the trader");
+        exchange.batchCancelOrders(orders);
+        cheats.stopPrank();
+    }
+}

--- a/test/exchange/batchSell.t.sol
+++ b/test/exchange/batchSell.t.sol
@@ -1,0 +1,360 @@
+pragma solidity ^0.8.20;
+
+import "../base/BaseTest.t.sol";
+import "../../src/libraries/OrderLib.sol";
+import "../helpers/HashLib.sol";
+import "../helpers/TraderContract.sol";
+
+contract Sell is BaseTest {
+    function setUp() public override {
+        super.setUp();
+
+        cheats.startPrank(address(executionDelegate));
+        fantasyCards.safeMint(user2); // 0
+        fantasyCards.safeMint(user2); // 1
+        cheats.stopPrank();
+
+        cheats.startPrank(user2);
+        fantasyCards.setApprovalForAll(address(executionDelegate), true);
+        cheats.stopPrank();
+    }
+
+    function _createMerkleRootAndProof(uint256[] memory tokenIds) internal pure returns (bytes32, bytes32[][] memory) {
+        bytes32[] memory leaves = new bytes32[](tokenIds.length);
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            leaves[i] = keccak256(abi.encodePacked(tokenIds[i]));
+        }
+        
+        bytes32 merkleRoot;
+        bytes32[][] memory proofs = new bytes32[][](tokenIds.length);
+        
+        if (tokenIds.length == 1) {
+            // For single token, the merkle root is just the hash of the token ID
+            merkleRoot = leaves[0];
+            proofs[0] = new bytes32[](0); // Empty proof for single token
+        } else {
+            // For multiple tokens, create merkle root and proofs as before
+            merkleRoot = keccak256(abi.encodePacked(leaves[0], leaves[1]));
+            
+            proofs[0] = new bytes32[](1);
+            proofs[0][0] = leaves[1];
+            proofs[1] = new bytes32[](1);
+            proofs[1][0] = leaves[0];
+        }
+        
+        return (merkleRoot, proofs);
+    }
+
+    function _createBuyOrder(
+        uint256 _tokenId,
+        uint256 _price,
+        bytes32 _merkleRoot
+    ) internal view returns (OrderLib.Order memory, bytes memory) {
+        OrderLib.Order memory buyOrder = OrderLib.Order(
+            user1,
+            OrderLib.Side.Buy,
+            address(fantasyCards),
+            _tokenId,
+            address(weth),
+            _price,
+            999999999999999999999,
+            _merkleRoot,
+            100_001
+        );
+
+        bytes32 orderHash = HashLib.getTypedDataHash(buyOrder, exchange.domainSeparator());
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(user1PrivateKey, orderHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        return (buyOrder, signature);
+    }
+
+    function test_successful_batchSell_WETH() public {
+        uint256[] memory tokenIds = new uint256[](2);
+        tokenIds[0] = 0;
+        tokenIds[1] = 1;
+        
+        (bytes32 merkleRoot, bytes32[][] memory merkleProofs) = _createMerkleRootAndProof(tokenIds);
+        
+        // Create orders with the merkle root
+        (OrderLib.Order memory buyOrder1, bytes memory buyerSignature1) = _createBuyOrder(0, 1 ether, merkleRoot);
+        (OrderLib.Order memory buyOrder2, bytes memory buyerSignature2) = _createBuyOrder(1, 2 ether, merkleRoot);
+
+        uint256 totalPrice = buyOrder1.price + buyOrder2.price;
+
+        // Setup WETH for buyer
+        cheats.startPrank(user1);
+        weth.getFaucet(totalPrice);
+        weth.approve(address(executionDelegate), totalPrice);
+        cheats.stopPrank();
+
+        // Setup arrays for batch sell
+        OrderLib.Order[] memory buyOrders = new OrderLib.Order[](2);
+        buyOrders[0] = buyOrder1;
+        buyOrders[1] = buyOrder2;
+
+        bytes[] memory buyerSignatures = new bytes[](2);
+        buyerSignatures[0] = buyerSignature1;
+        buyerSignatures[1] = buyerSignature2;
+
+        // Execute sell
+        cheats.startPrank(user2, user2);
+        exchange.batchSell(buyOrders, buyerSignatures, tokenIds, merkleProofs);
+        cheats.stopPrank();
+
+        // Assertions
+        assertEq(weth.balanceOf(treasury), (totalPrice * exchange.protocolFeeBps()) / exchange.INVERSE_BASIS_POINT());
+        assertEq(weth.balanceOf(user2), totalPrice - weth.balanceOf(treasury));
+        assertEq(weth.balanceOf(user1), 0);
+        assertEq(fantasyCards.balanceOf(user2), 0);
+        assertEq(fantasyCards.balanceOf(user1), 2);
+    }
+
+    function test_unsuccessful_batchSell_ETH_payment_token() public {
+        bytes32[] memory proof1 = new bytes32[](0);
+
+        // Create buy order with ETH as payment token (not allowed)
+        OrderLib.Order memory buyOrder1 = OrderLib.Order(
+            user1,
+            OrderLib.Side.Buy,
+            address(fantasyCards),
+            0,
+            address(0), // ETH address
+            1 ether,
+            999999999999999999999,
+            bytes32(0),
+            100_001
+        );
+
+        // Sign order
+        bytes32 orderHash1 = HashLib.getTypedDataHash(buyOrder1, exchange.domainSeparator());
+        (uint8 vBuyer1, bytes32 rBuyer1, bytes32 sBuyer1) = vm.sign(user1PrivateKey, orderHash1);
+        bytes memory buyerSignature1 = abi.encodePacked(rBuyer1, sBuyer1, vBuyer1);
+
+        OrderLib.Order[] memory buyOrders = new OrderLib.Order[](1);
+        buyOrders[0] = buyOrder1;
+        bytes[] memory buyerSignatures = new bytes[](1);
+        buyerSignatures[0] = buyerSignature1;
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = 0;
+        bytes32[][] memory merkleProofs = new bytes32[][](1);
+        merkleProofs[0] = proof1;
+
+        // Execute sell
+        cheats.startPrank(user2, user2);
+        cheats.expectRevert("payment token can not be ETH for buy order");
+        exchange.batchSell(buyOrders, buyerSignatures, tokenIds, merkleProofs);
+        cheats.stopPrank();
+    }
+
+    function test_unsuccessful_batchSell_array_length_mismatch() public {
+        OrderLib.Order[] memory buyOrders = new OrderLib.Order[](3);
+        bytes[] memory buyerSignatures = new bytes[](2);
+        uint256[] memory tokenIds = new uint256[](2);
+        bytes32[][] memory merkleProofs = new bytes32[][](2);
+
+        // Execute sell
+        cheats.startPrank(user2, user2);
+        cheats.expectRevert("Array length mismatch");
+        exchange.batchSell(buyOrders, buyerSignatures, tokenIds, merkleProofs);
+        cheats.stopPrank();
+    }
+
+    function test_unsuccessful_batchSell_expired_order() public {
+        bytes32[] memory proof1 = new bytes32[](0);
+
+        // Create expired buy order
+        OrderLib.Order memory buyOrder1 = OrderLib.Order(
+            user1,
+            OrderLib.Side.Buy,
+            address(fantasyCards),
+            0,
+            address(weth),
+            1 ether,
+            block.timestamp - 1, // expired
+            bytes32(0),
+            100_001
+        );
+
+        // Sign order
+        bytes32 orderHash1 = HashLib.getTypedDataHash(buyOrder1, exchange.domainSeparator());
+        (uint8 vBuyer1, bytes32 rBuyer1, bytes32 sBuyer1) = vm.sign(user1PrivateKey, orderHash1);
+        bytes memory buyerSignature1 = abi.encodePacked(rBuyer1, sBuyer1, vBuyer1);
+
+        OrderLib.Order[] memory buyOrders = new OrderLib.Order[](1);
+        buyOrders[0] = buyOrder1;
+        bytes[] memory buyerSignatures = new bytes[](1);
+        buyerSignatures[0] = buyerSignature1;
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = 0;
+        bytes32[][] memory merkleProofs = new bytes32[][](1);
+        merkleProofs[0] = proof1;
+
+        // Execute sell
+        cheats.startPrank(user2, user2);
+        cheats.expectRevert("order expired");
+        exchange.batchSell(buyOrders, buyerSignatures, tokenIds, merkleProofs);
+        cheats.stopPrank();
+    }
+
+    function test_unsuccessful_batchSell_invalid_merkle_proof() public {
+        uint256[] memory tokenIds = new uint256[](2);
+        tokenIds[0] = 0;
+        tokenIds[1] = 1;
+        
+        (bytes32 merkleRoot, bytes32[][] memory merkleProofs) = _createMerkleRootAndProof(tokenIds);
+        
+        // Create orders with the merkle root
+        (OrderLib.Order memory buyOrder1, bytes memory buyerSignature1) = _createBuyOrder(0, 1 ether, merkleRoot);
+        (OrderLib.Order memory buyOrder2, bytes memory buyerSignature2) = _createBuyOrder(1, 2 ether, merkleRoot);
+
+        uint256 totalPrice = buyOrder1.price + buyOrder2.price;
+
+        // Setup WETH for buyer
+        cheats.startPrank(user1, user1);
+        weth.getFaucet(totalPrice);
+        weth.approve(address(executionDelegate), totalPrice);
+        cheats.stopPrank();
+
+        OrderLib.Order[] memory buyOrders = new OrderLib.Order[](2);
+        buyOrders[0] = buyOrder1;
+        buyOrders[1] = buyOrder2;
+
+        bytes[] memory buyerSignatures = new bytes[](2);
+        buyerSignatures[0] = buyerSignature1;
+        buyerSignatures[1] = buyerSignature2;
+
+        // Tamper with merkle proofs
+        merkleProofs[0][0] = bytes32(uint256(1234));
+
+        cheats.startPrank(user2, user2);
+        cheats.expectRevert("invalid tokenId");
+        exchange.batchSell(buyOrders, buyerSignatures, tokenIds, merkleProofs);
+        cheats.stopPrank();
+    }
+
+    function test_unsuccessful_batchSell_unauthorized_seller() public {
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = 0;
+        
+        (bytes32 merkleRoot, bytes32[][] memory merkleProofs) = _createMerkleRootAndProof(tokenIds);
+        
+        (OrderLib.Order memory buyOrder, bytes memory buyerSignature) = _createBuyOrder(0, 1 ether, merkleRoot);
+
+        // Setup WETH for buyer
+        cheats.startPrank(user1, user1);
+        weth.getFaucet(1 ether);
+        weth.approve(address(executionDelegate), 1 ether);
+        cheats.stopPrank();
+
+        OrderLib.Order[] memory buyOrders = new OrderLib.Order[](1);
+        buyOrders[0] = buyOrder;
+
+        bytes[] memory buyerSignatures = new bytes[](1);
+        buyerSignatures[0] = buyerSignature;
+
+        cheats.startPrank(user3, user3);
+        cheats.expectRevert(abi.encodeWithSignature(
+            "ERC721IncorrectOwner(address,uint256,address)",
+            user3,  // from address (incorrect owner)
+            0,      // tokenId
+            user2   // actual owner
+        ));
+        exchange.batchSell(buyOrders, buyerSignatures, tokenIds, merkleProofs);
+        cheats.stopPrank();
+    }
+
+    function test_unsuccessful_batchSell_insufficient_buyer_balance() public {
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = 0;
+        
+        bytes32[][] memory merkleProofs = new bytes32[][](1);
+        merkleProofs[0] = new bytes32[](0);
+        
+        // Create order with high price
+        (OrderLib.Order memory buyOrder, bytes memory buyerSignature) = _createBuyOrder(0, 1000000 ether, bytes32(0));
+
+        OrderLib.Order[] memory buyOrders = new OrderLib.Order[](1);
+        buyOrders[0] = buyOrder;
+
+        bytes[] memory buyerSignatures = new bytes[](1);
+        buyerSignatures[0] = buyerSignature;
+
+        // Don't fund the buyer with enough WETH
+        cheats.startPrank(user1);
+        weth.getFaucet(1 ether);
+        weth.approve(address(executionDelegate), 1000000 ether);
+        cheats.stopPrank();
+
+        cheats.startPrank(user2, user2);
+        cheats.expectRevert();  // ERC20 transfer will fail
+        exchange.batchSell(buyOrders, buyerSignatures, tokenIds, merkleProofs);
+        cheats.stopPrank();
+    }
+
+    function test_successful_batchSell_single_token() public {
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = 0;
+        
+        // bytes32[][] memory merkleProofs = new bytes32[][](1);
+        // merkleProofs[0] = new bytes32[](0);
+
+        (bytes32 merkleRoot, bytes32[][] memory merkleProofs) = _createMerkleRootAndProof(tokenIds);
+        
+        (OrderLib.Order memory buyOrder, bytes memory buyerSignature) = _createBuyOrder(0, 1 ether,merkleRoot);
+
+        // Setup WETH for buyer
+        cheats.startPrank(user1);
+        weth.getFaucet(1 ether);
+        weth.approve(address(executionDelegate), 1 ether);
+        cheats.stopPrank();
+
+        OrderLib.Order[] memory buyOrders = new OrderLib.Order[](1);
+        buyOrders[0] = buyOrder;
+
+        bytes[] memory buyerSignatures = new bytes[](1);
+        buyerSignatures[0] = buyerSignature;
+
+        uint256 initialBalance = weth.balanceOf(user2);
+
+        cheats.startPrank(user2, user2);
+        exchange.batchSell(buyOrders, buyerSignatures, tokenIds, merkleProofs);
+        cheats.stopPrank();
+
+        assertEq(fantasyCards.ownerOf(0), user1);
+        assertEq(weth.balanceOf(user2), initialBalance + 1 ether - (1 ether * exchange.protocolFeeBps()) / exchange.INVERSE_BASIS_POINT());
+    }
+
+    function test_unsuccessful_batchSell_reused_order() public {
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = 0;
+        
+        bytes32[][] memory merkleProofs = new bytes32[][](1);
+        merkleProofs[0] = new bytes32[](0);
+
+        (bytes32 merkleRoot,) = _createMerkleRootAndProof(tokenIds);
+        
+        (OrderLib.Order memory buyOrder, bytes memory buyerSignature) = _createBuyOrder(0, 1 ether, merkleRoot);
+
+        // Setup WETH for buyer
+        cheats.startPrank(user1);
+        weth.getFaucet(2 ether); // Extra WETH for potential second transaction
+        weth.approve(address(executionDelegate), 2 ether);
+        cheats.stopPrank();
+
+        OrderLib.Order[] memory buyOrders = new OrderLib.Order[](1);
+        buyOrders[0] = buyOrder;
+
+        bytes[] memory buyerSignatures = new bytes[](1);
+        buyerSignatures[0] = buyerSignature;
+
+        // First execution
+        cheats.startPrank(user2, user2);
+        exchange.batchSell(buyOrders, buyerSignatures, tokenIds, merkleProofs);
+        
+        // Try to execute the same order again
+        cheats.expectRevert("buy order cancelled or filled");
+        exchange.batchSell(buyOrders, buyerSignatures, tokenIds, merkleProofs);
+        cheats.stopPrank();
+    }
+}

--- a/test/exchange/buy.t.sol
+++ b/test/exchange/buy.t.sol
@@ -364,7 +364,7 @@ contract Buy is BaseTest {
         (uint8 vSeller, bytes32 rSeller, bytes32 sSeller) = vm.sign(user1PrivateKey, orderHash);
         bytes memory sellerSignature = abi.encodePacked(rSeller, sSeller, vSeller);
 
-        exchange.setMinimumPricePerPaymentToken(address(0), sellOrder.price + 1);
+        exchange.whiteListPaymentToken(address(0), sellOrder.price + 1);
 
         cheats.deal(user2, 1 ether);
 

--- a/test/exchange/buy_fuzz.t.sol
+++ b/test/exchange/buy_fuzz.t.sol
@@ -46,7 +46,7 @@ contract Buy_fuzz is BaseTest {
 
         // Execute buy
         cheats.startPrank(user2, user2);
-        exchange.buy(sellOrder, sellerSignature);
+        exchange.buy(sellOrder, sellerSignature, false);
         cheats.stopPrank();
 
         // Check balances
@@ -85,7 +85,7 @@ contract Buy_fuzz is BaseTest {
 
         // Execute buy
         cheats.startPrank(user2, user2);
-        exchange.buy{value: sellOrder.price}(sellOrder, sellerSignature);
+        exchange.buy{value: sellOrder.price}(sellOrder, sellerSignature, false);
         cheats.stopPrank();
 
         // Check balances

--- a/test/helpers/TraderContract.sol
+++ b/test/helpers/TraderContract.sol
@@ -55,4 +55,13 @@ contract TraderContract {
     function mintOnMinter(uint256 configId, bytes32[] calldata merkleProof, uint256 maxPrice) public {
         minter.mint(configId, merkleProof, maxPrice);
     }
+
+    function batchMintToOnMinter(
+        uint256 configId,
+        bytes32[] calldata merkleProof,
+        uint256 maxPrice,
+        address[] calldata recipients
+    ) external payable {
+        minter.batchMintCardsTo(configId, merkleProof, maxPrice, recipients);
+    }
 }

--- a/test/helpers/TraderContract.sol
+++ b/test/helpers/TraderContract.sol
@@ -58,10 +58,10 @@ contract TraderContract {
 
     function batchMintToOnMinter(
         uint256 configId,
-        bytes32[] calldata merkleProof,
+        bytes32[][] calldata merkleProofs,
         uint256 maxPrice,
         address[] calldata recipients
     ) external payable {
-        minter.batchMintCardsTo(configId, merkleProof, maxPrice, recipients);
+        minter.batchMintCardsTo(configId, merkleProofs, maxPrice, recipients);
     }
 }

--- a/test/helpers/TraderContract.sol
+++ b/test/helpers/TraderContract.sol
@@ -27,7 +27,7 @@ contract TraderContract {
     // Function to initiate a buy on the Exchange contract
     function buyOnExchange(OrderLib.Order calldata sellOrder, bytes calldata sellerSignature) external payable {
         // Directly call the buy function of the Exchange contract
-        exchange.buy{value: msg.value}(sellOrder, sellerSignature);
+        exchange.buy{value: msg.value}(sellOrder, sellerSignature, false);
     }
 
     function batchBuyOnExchange(
@@ -35,7 +35,7 @@ contract TraderContract {
         bytes[] calldata sellerSignatures
     ) external payable {
         // Directly call the batchBuy function of the Exchange contract
-        exchange.batchBuy{value: msg.value}(sellOrders, sellerSignatures);
+        exchange.batchBuy{value: msg.value}(sellOrders, sellerSignatures, new bool[](sellOrders.length));
     }
 
     // Function to initiate a sell on the Exchange contract

--- a/test/helpers/TraderContract.sol
+++ b/test/helpers/TraderContract.sol
@@ -35,7 +35,7 @@ contract TraderContract {
         bytes[] calldata sellerSignatures
     ) external payable {
         // Directly call the batchBuy function of the Exchange contract
-        exchange.batchBuy{value: msg.value}(sellOrders, sellerSignatures, new bool[](sellOrders.length));
+        exchange.batchBuy{value: msg.value}(sellOrders, sellerSignatures, false);
     }
 
     // Function to initiate a sell on the Exchange contract

--- a/test/minter/batchBurn.t.sol
+++ b/test/minter/batchBurn.t.sol
@@ -1,0 +1,67 @@
+pragma solidity ^0.8.20;
+
+import "../base/BaseTest.t.sol";
+
+contract BatchBurn is BaseTest {
+    function setUp() public override {
+        super.setUp();
+        cheats.startPrank(address(executionDelegate));
+        for (uint256 i = 0; i < 15; i++) {
+            fantasyCards.safeMint(user1);
+        }
+        cheats.stopPrank();
+    }
+
+    function test_successful_batchBurn() public {
+        uint256[] memory tokenIds = new uint256[](5);
+        for (uint256 i = 0; i < 5; i++) {
+            tokenIds[i] = i;
+        }
+        address collection = address(fantasyCards);
+        
+        cheats.startPrank(user1);
+        minter.batchBurn(collection, tokenIds);
+        cheats.stopPrank();
+
+        // Verify all tokens are burned
+        for (uint256 i = 0; i < 5; i++) {
+            cheats.expectRevert(); // Token should not exist after burn
+            fantasyCards.ownerOf(i);
+        }
+    }
+
+    function test_unsuccessful_batchBurn_userNotOwner() public {
+        uint256[] memory tokenIds = new uint256[](5);
+        for (uint256 i = 0; i < 5; i++) {
+            tokenIds[i] = i;
+        }
+        address collection = address(fantasyCards);
+        
+        cheats.startPrank(user2);
+        cheats.expectRevert("caller does not own one of the tokens");
+        minter.batchBurn(collection, tokenIds);
+        cheats.stopPrank();
+    }
+
+    function test_unsuccessful_batchBurn_emptyArray() public {
+        uint256[] memory tokenIds = new uint256[](0);
+        address collection = address(fantasyCards);
+        
+        cheats.startPrank(user1);
+        cheats.expectRevert("no tokens to burn");
+        minter.batchBurn(collection, tokenIds);
+        cheats.stopPrank();
+    }
+
+    function test_unsuccessful_batchBurn_collection_not_whitelisted() public {
+        uint256[] memory tokenIds = new uint256[](5);
+        for (uint256 i = 0; i < 5; i++) {
+            tokenIds[i] = i;
+        }
+
+        cheats.startPrank(user1);
+        cheats.expectRevert("Collection is not whitelisted");
+        minter.batchBurn(address(0), tokenIds);
+        cheats.stopPrank();
+    }
+}

--- a/test/minter/batchBurnToDraw.t.sol
+++ b/test/minter/batchBurnToDraw.t.sol
@@ -1,0 +1,113 @@
+pragma solidity ^0.8.20;
+
+import "../base/BaseTest.t.sol";
+
+contract BatchBurnToDraw is BaseTest {
+    function setUp() public override {
+        super.setUp();
+        cheats.startPrank(address(executionDelegate));
+        for (uint256 i = 0; i < 30; i++) {
+            fantasyCards.safeMint(user1);
+        }
+        cheats.stopPrank();
+    }
+
+    function test_successful_batchBurnToDraw() public {
+        uint256 cardsRequiredForBurnToDraw = minter.cardsRequiredForBurnToDraw();
+        console.log("cardsRequiredForBurnToDraw", cardsRequiredForBurnToDraw);
+        uint256[][] memory tokenIdsBatch = new uint256[][](2);
+        tokenIdsBatch[0] = new uint256[](cardsRequiredForBurnToDraw);
+        tokenIdsBatch[1] = new uint256[](cardsRequiredForBurnToDraw);
+
+        for (uint256 i = 0; i < cardsRequiredForBurnToDraw; i++) {
+            tokenIdsBatch[0][i] = i;
+            tokenIdsBatch[1][i] = i + cardsRequiredForBurnToDraw;
+        }
+
+        address collection = address(fantasyCards);
+        cheats.startPrank(user1, user1);
+        minter.batchBurnToDraw(tokenIdsBatch, collection);
+        cheats.stopPrank();
+
+        // Verify that the tokens have been burned and new ones minted
+        for (uint256 j = 0; j < 2; j++) {
+            for (uint256 i = 0; i < cardsRequiredForBurnToDraw; i++) {
+                cheats.expectRevert(); // TODO: proper revert message
+                fantasyCards.ownerOf(i + (j * cardsRequiredForBurnToDraw));
+            }
+        }
+        assertEq(fantasyCards.ownerOf(cardsRequiredForBurnToDraw * 2), user1);
+        assertEq(fantasyCards.ownerOf(cardsRequiredForBurnToDraw * 2 + 1), user1);
+        assertEq(fantasyCards.tokenCounter(), cardsRequiredForBurnToDraw * 2 + 2);
+    }
+
+    function test_unsuccessful_batchBurnToDraw_wrongCardNumber() public {
+        uint256 cardsRequiredForBurnToDraw = minter.cardsRequiredForBurnToDraw();
+        uint256[][] memory tokenIdsBatch = new uint256[][](1);
+        uint256[] memory tokenIds = new uint256[](cardsRequiredForBurnToDraw - 1);
+
+        for (uint256 i = 0; i < cardsRequiredForBurnToDraw - 1; i++) {
+            tokenIds[i] = i;
+        }
+
+        tokenIdsBatch[0] = tokenIds;
+        address collection = address(fantasyCards);
+        cheats.startPrank(user1);
+        cheats.expectRevert("wrong amount of cards to draw new cards");
+        minter.batchBurnToDraw(tokenIdsBatch, collection);
+        cheats.stopPrank();
+    }
+
+    function test_unsuccessful_batchBurnToDraw_userNotOwner() public {
+        uint256 cardsRequiredForBurnToDraw = minter.cardsRequiredForBurnToDraw();
+        uint256[][] memory tokenIdsBatch = new uint256[][](1);
+        uint256[] memory tokenIds = new uint256[](cardsRequiredForBurnToDraw);
+
+        for (uint256 i = 0; i < cardsRequiredForBurnToDraw; i++) {
+            tokenIds[i] = i;
+        }
+
+        tokenIdsBatch[0] = tokenIds;
+        address collection = address(fantasyCards);
+        cheats.startPrank(user2);
+        cheats.expectRevert("caller does not own one of the tokens");
+        minter.batchBurnToDraw(tokenIdsBatch, collection);
+        cheats.stopPrank();
+    }
+
+    function test_unsuccessful_batchBurnToDraw_collection_not_whitelisted() public {
+        uint256 cardsRequiredForBurnToDraw = minter.cardsRequiredForBurnToDraw();
+        uint256[][] memory tokenIdsBatch = new uint256[][](1);
+        uint256[] memory tokenIds = new uint256[](cardsRequiredForBurnToDraw);
+
+        for (uint256 i = 0; i < cardsRequiredForBurnToDraw; i++) {
+            tokenIds[i] = i;
+        }
+
+        tokenIdsBatch[0] = tokenIds;
+        cheats.startPrank(user1);
+        cheats.expectRevert("Collection is not whitelisted");
+        minter.batchBurnToDraw(tokenIdsBatch, address(0));
+        cheats.stopPrank();
+    }
+
+    function test_unsuccessful_batchBurnToDraw_different_array_lengths() public {
+        uint256 cardsRequiredForBurnToDraw = minter.cardsRequiredForBurnToDraw();
+        uint256[][] memory tokenIdsBatch = new uint256[][](2);
+        tokenIdsBatch[0] = new uint256[](cardsRequiredForBurnToDraw);
+        tokenIdsBatch[1] = new uint256[](cardsRequiredForBurnToDraw - 1); // Different length
+
+        for (uint256 i = 0; i < cardsRequiredForBurnToDraw - 1; i++) {
+            tokenIdsBatch[0][i] = i;
+            tokenIdsBatch[1][i] = i + cardsRequiredForBurnToDraw;
+        }
+        // Add the last element to the first array
+        tokenIdsBatch[0][cardsRequiredForBurnToDraw - 1] = cardsRequiredForBurnToDraw - 1;
+
+        address collection = address(fantasyCards);
+        cheats.startPrank(user1);
+        cheats.expectRevert("wrong amount of cards to draw new cards");
+        minter.batchBurnToDraw(tokenIdsBatch, collection);
+        cheats.stopPrank();
+    }
+}

--- a/test/minter/batchMintTo.t.sol
+++ b/test/minter/batchMintTo.t.sol
@@ -51,8 +51,12 @@ contract BatchMintTo is BaseTest {
             mintConfig.startTimestamp,
             mintConfig.expirationTimestamp
         );
-        
-        minter.batchMintCardsTo(0, new bytes32[](0), 1 ether, recipients);
+
+        bytes32[][] memory merkleProofs = new bytes32[][](2);
+        merkleProofs[0] = new bytes32[](0);
+        merkleProofs[1] = new bytes32[](0);
+
+        minter.batchMintCardsTo(0, merkleProofs, 1 ether, recipients);
         cheats.stopPrank();
 
         assertEq(fantasyCards.balanceOf(user1), mintConfig.cardsPerPack);

--- a/test/minter/batchMintTo.t.sol
+++ b/test/minter/batchMintTo.t.sol
@@ -1,0 +1,61 @@
+pragma solidity ^0.8.20;
+
+import "../base/BaseTest.t.sol";
+import "../helpers/TraderContract.sol";
+
+contract BatchMintTo is BaseTest {
+    struct MintConfig {
+        address collection;
+        uint256 cardsPerPack;
+        uint256 maxPacks;
+        address paymentToken;
+        uint256 fixedPrice;
+        uint256 maxPacksPerAddress;
+        bool requiresWhitelist;
+        bytes32 merkleRoot;
+        uint256 startTimestamp;
+        uint256 expirationTimestamp;
+    }
+
+    function setUp() public override {
+        super.setUp();
+    }
+
+    function test_batchMintTo() public {
+        address[] memory recipients = new address[](2);
+        recipients[0] = user1;
+        recipients[1] = user2;
+
+        MintConfig memory mintConfig;
+        mintConfig.collection = address(fantasyCards);
+        mintConfig.cardsPerPack = 80;
+        mintConfig.maxPacks = 10;
+        mintConfig.paymentToken = address(weth);
+        mintConfig.fixedPrice = 0;
+        mintConfig.maxPacksPerAddress = 0;
+        mintConfig.requiresWhitelist = false;
+        mintConfig.merkleRoot = bytes32(0);
+        mintConfig.startTimestamp = block.timestamp;
+        mintConfig.expirationTimestamp = 0;
+
+        cheats.startPrank(mintConfigMaster, mintConfigMaster);
+        minter.newMintConfig(
+            mintConfig.collection,
+            mintConfig.cardsPerPack,
+            mintConfig.maxPacks,
+            mintConfig.paymentToken,
+            mintConfig.fixedPrice,
+            mintConfig.maxPacksPerAddress,
+            mintConfig.requiresWhitelist,
+            mintConfig.merkleRoot,
+            mintConfig.startTimestamp,
+            mintConfig.expirationTimestamp
+        );
+        
+        minter.batchMintCardsTo(0, new bytes32[](0), 1 ether, recipients);
+        cheats.stopPrank();
+
+        assertEq(fantasyCards.balanceOf(user1), mintConfig.cardsPerPack);
+        assertEq(fantasyCards.balanceOf(user2), mintConfig.cardsPerPack);
+    }
+}

--- a/test/minter/newMintConfig.t.sol
+++ b/test/minter/newMintConfig.t.sol
@@ -8,6 +8,7 @@ contract NewMintConfig is BaseTest {
     }
 
     function test_successful_newMintConfig() public {
+        minter.whiteListCollection(address(0x1));
         // Act
         cheats.startPrank(mintConfigMaster);
         minter.newMintConfig(
@@ -55,6 +56,7 @@ contract NewMintConfig is BaseTest {
     }
 
     function test_mintConfigIdCounter() public {
+        minter.whiteListCollection(address(0x1));
         // Arrange
         address collection = address(0x1);
         uint256 cardsPerPack = 10;

--- a/test/minter/setCollectionForMintConfig.t.sol
+++ b/test/minter/setCollectionForMintConfig.t.sol
@@ -48,6 +48,7 @@ contract SetCollectionForMintConfig is BaseTest {
     }
 
     function test_successful_setCollectionForMintConfig() public {
+        minter.whiteListCollection(address(0x123));
         cheats.startPrank(mintConfigMaster);
         minter.setCollectionForMintConfig(0, address(0x123));
         cheats.stopPrank();
@@ -64,6 +65,7 @@ contract SetCollectionForMintConfig is BaseTest {
     }
 
     function test_unsuccessful_setCollectionForMintConfig_zero() public {
+        minter.whiteListCollection(address(0));
         cheats.startPrank(mintConfigMaster);
         cheats.expectRevert("Collection address cannot the zero address");
         minter.setCollectionForMintConfig(0, address(0));
@@ -71,6 +73,7 @@ contract SetCollectionForMintConfig is BaseTest {
     }
 
     function test_unsuccessful_setCollectionForMintConfig_invalid_mintConfigId() public {
+        minter.whiteListCollection(address(0x123));
         cheats.startPrank(mintConfigMaster);
         cheats.expectRevert("Invalid mintConfigId");
         minter.setCollectionForMintConfig(1, address(0x123));


### PR DESCRIPTION
New Functions Overview

## Exchange.sol

### Creation of `batchCancelOrder`

Moved `cancelOrder` logic into internal function `_cancelOrder`. Added function `batchCancelOrder` that should cancel multiple orders at once. Kept original `cancelOrder` to not break integrations.

### Creation of `batchSell` 

Moved `sell` logic into internal function `_sell`. Added function `batchSell` that should execute multiple buy order at once. Kept original `sell` method to not break integrations.

Emits new event `BatchSell`

### Modification of `batchBuy` 

New game mechanism will require the need to sweep sell cards and burn them to get specific rewards. The creation of a `batchBuyAndBurn ` function was suggested. However for simplicity we add a new bool parameter to the `batchBuy` method: `burnAfterPurchase`. If true, the card will be burned in the internal method `_buy` that was extended with the same extra parameter. 

This scheme was implemented to avoid giving an EOA the execution delegate role. 

Emits one of two new events : `BatchBuyAndBurn` or `BatchBuy`


## Minter.sol

### Creation of `batchBurn`

Purpose: Allow token holders to burn their own tokens. Implementation: Simply allow anyone to call the burn function for an array of token. Access: Public function, only callable by token owner or approved address. 

Implementation checks that user is burning a whitelisted collection token and that he is the owner of each token. Uses execution delegate to burn the tokens. Emits new event `BatchBurn`.

### Creation of `batchMintCardsTo`

For game rewards it is useful for admins to directly mint cards to a specific address/group of addresses. We modify the `mint` method to take a recipient address as parameter and create the new internal method `_mintCardsTo`. We can then call this method via a public access controlled method `batchMintCardsTo` that can take as parameters an array of recipients. 

We still keep the concept of config id for easier reward management (versus a direct mintCardsTo method with no config id parameter).

emits the event `Mint` similar to the one from the `mint` method


### Creation of `batchBurnToDraw`

Moved `burnToDraw` logic into internal method `_burnToDraw`. Added method `batchBurnToDraw` that should execute multiple burn to draw at once. Kept original `burnToDraw` to not break integrations.

